### PR TITLE
integrate sync_wait.hpp

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020 ETH Zurich 
+//  Copyright (c) 2020 ETH Zurich
 //  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -22,13 +22,19 @@
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/type_support/meta.hpp>
 #include <hpx/type_support/pack.hpp>
-#include <hpx/type_support/unused.hpp
+#include <hpx/type_support/unused.hpp>
 
 #include <atomic>
 #include <exception>
 #include <mutex>
 #include <type_traits>
 #include <utility>
+
+enum class Sync_wait_type
+    {
+        single,
+        variant
+    };
 
 namespace hpx::execution::experimental::detail {
 
@@ -57,10 +63,14 @@ namespace hpx::execution::experimental::detail {
 
     template <typename Pack>
     using make_decayed_pack_t = typename make_decayed_pack<Pack>::type;
-    
-    // integrate sync_wait and sync_wait_with_variant
-    enum class Sync_wait_type { single=0, variant=1};
 
+    // integrate sync_wait and sync_wait_with_variant
+    //enum class Sync_wait_type
+    //{
+    //    single,
+    //    variant
+    //};
+    // Sync_wait_type Type;
     template <typename Sender, Sync_wait_type Type>
     struct sync_wait_receiver
     {
@@ -81,13 +91,15 @@ namespace hpx::execution::experimental::detail {
         // value_types for a sender. In particular, split() explicitly adds a
         // const& to all tuple members in a way that prevent simply passing
         // decayed_tuple to predecessor_value_types.
-        using single_result_type = make_decayed_pack_t <
-            single_variant_t<predecessor_value_types<hpx::tuple, meta::pack>>;
+        using single_result_type = make_decayed_pack_t<
+            single_variant_t<predecessor_value_types<hpx::tuple, meta::pack>>>;
+
         // The template should compute the result type of whatever returned from
         // sync_wait or sync_wait_with_variant by checking Sync_wait_type is single or variant
-        using result_type = std::conditional<Type == Sync_wait_type::single,
-            hpx::variant<single_result_type>,
-            predecessor_value_types<hpx::tuple, hpx::variant>>; // ::type
+        using result_type =
+            std::conditional<Type == Sync_wait_type::single,
+                hpx::variant<single_result_type>,
+                predecessor_value_types<hpx::tuple, hpx::variant>>;
 
         // The type of errors to store in the variant. This in itself is a
         // variant.
@@ -183,19 +195,120 @@ namespace hpx::execution::experimental::detail {
 }    // namespace hpx::execution::experimental::detail
 
 namespace hpx::this_thread::experimental {
+    
+    // this_thread::sync_wait is a sender consumer that submits the work
+    // described by the provided sender for execution, similarly to
+    // ensure_started, except that it blocks the current std::thread or thread
+    // of main until the work is completed, and returns an optional tuple of
+    // values that were sent by the provided sender on its completion of work.
+    // Where 4.20.1 execution::schedule and 4.20.3 execution::transfer_just are
+    // meant to enter the domain of senders, sync_wait is meant to exit the
+    // domain of senders, retrieving the result of the task graph.
+    //
+    // If the provided sender sends an error instead of values, sync_wait throws
+    // that error as an exception, or rethrows the original exception if the
+    // error is of type std::exception_ptr.
+    //
+    // If the provided sender sends the "stopped" signal instead of values,
+    // sync_wait returns an empty optional.
+    //
+    // For an explanation of the requires clause, see 5.8 All senders are typed.
+    // That clause also explains another sender consumer, built on top of
+    // sync_wait: sync_wait_with_variant.
+    //
+    // Note: This function is specified inside hpx::this_thread::experimental,
+    // and not inside hpx::execution::experimental. This is because sync_wait
+    // has to block the current execution agent, but determining what the
+    // current execution agent is is not reliable. Since the standard does not
+    // specify any functions on the current execution agent other than those in
+    // std::this_thread, this is the flavor of this function that is being
+    // proposed.
+
+    // this_thread::sync_wait and this_thread::sync_wait_with_variant are used
+    // to block a current thread until a sender passed into it as an argument
+    // has completed, and to obtain the values (if any) it completed with.
+    //
+    // For any receiver r created by an implementation of sync_wait and
+    // sync_wait_with_variant, the expressions get_scheduler(get_env(r)) and
+    // get_delegatee_scheduler(get_env(r)) shall be well-formed. For a receiver
+    // created by the default implementation of this_thread::sync_wait, these
+    // expressions shall return a scheduler to the same thread-safe,
+    // first-in-first-out queue of work such that tasks scheduled to the queue
+    // execute on the thread of the caller of sync_wait. [Note: The scheduler
+    // for an instance of execution::run_loop that is a local variable within
+    // sync_wait is one valid implementation. -- end note]
+    //
+    // The templates sync-wait-type and sync-wait-with-variant-type are used to
+    // determine the return types of this_thread::sync_wait and
+    // this_thread::sync_wait_with_variant. Let sync-wait-env be the type of the
+    // expression get_env(r) where r is an instance of the receiver created by
+    // the default implementation of sync_wait. Then:
+    //
+    // template<sender<sync-wait-env> S> using sync-wait-type =
+    //  optional<execution::value_types_of_t< S, sync-wait-env, decayed-tuple,
+    //  type_identity_t>>;
+    //
+    //  template<sender<sync-wait-env> S> using sync-wait-with-variant-type =
+    //  optional<execution::into-variant-type<S, sync-wait-env>>;
+    //
+    // The name this_thread::sync_wait denotes a customization point object. For
+    // some subexpression s, let S be decltype((s)). If execution::sender<S,
+    // sync-wait-env> is false, or the number of the arguments
+    // completion_signatures_of_t<S, sync-wait-env>::value_types passed into the
+    // Variant template parameter is not 1, this_thread::sync_wait is
+    // ill-formed. Otherwise, this_thread::sync_wait is expression-equivalent
+    // to:
+    //
+    // 1. tag_invoke(this_thread::sync_wait,
+    //          execution::get_completion_scheduler< execution::set_value_t>(s),
+    //          s), if this expression is valid.
+    //
+    //      - Mandates: The type of the tag_invoke expression above is
+    //                  sync-wait-type<S, sync-wait-env>.
+    //
+    // 2. Otherwise, tag_invoke(this_thread::sync_wait, s), if this expression
+    //    is valid and its type is.
+    //
+    //      - Mandates: The type of the tag_invoke expression above is
+    //                  sync-wait-type<S, sync-wait-env>.
+    //
+    // 3. Otherwise:
+    //
+    //      1. Constructs a receiver r.
+    //
+    //      2. Calls execution::connect(s, r), resulting in an operation state
+    //         op_state, then calls execution::start(op_state).
+    //
+    //      3. Blocks the current thread until a receiver completion-signal of r
+    //         is called. When it is:
+    //
+    //          1. If execution::set_value(r, ts...) has been called, returns
+    //              sync-wait-type<S, sync-wait-env>{
+    //                  decayed-tuple<decltype(ts)...>{ts...}}.
+    //              If that expression exits exceptionally, the exception is
+    //              propagated to the caller of sync_wait.
+    //
+    //          2. If execution::set_error(r, e) has been called, let E be the
+    //             decayed type of e. If E is exception_ptr, calls
+    //             std::rethrow_exception(e). Otherwise, if the E is error_code,
+    //             throws system_error(e). Otherwise, throws e.
+    //
+    //          3. If execution::set_stopped(r) has been called, returns
+    //             sync-wait-type<S, sync-wait-env>{}.
+    //
 
     inline constexpr struct sync_wait_t final
       : hpx::functional::detail::tag_priority<sync_wait_t>
     {
     private:
         // clang-format off
-        template <typename Sender,
+        template <typename Sender, Sync_wait_type Type,
             HPX_CONCEPT_REQUIRES_(
                 hpx::execution::experimental::is_sender_v<Sender> &&
                 hpx::execution::experimental::detail::
                     is_completion_scheduler_tag_invocable_v<
                         hpx::execution::experimental::set_value_t,
-                        Sender, sync_wait_t
+                        Sender, Type, sync_wait_t
                     >
             )>
         // clang-format on
@@ -211,16 +324,17 @@ namespace hpx::this_thread::experimental {
         }
 
         // clang-format off
-        template <typename Sender,
+        template <typename Sender, Sync_wait_type Type,
             HPX_CONCEPT_REQUIRES_(
                 hpx::execution::experimental::is_sender_v<Sender>
             )>
         // clang-format on
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
-            sync_wait_t, Sender&& sender, Type&& tp)
+            sync_wait_t, Sender&& sender)
         {
             using receiver_type =
-                hpx::execution::experimental::detail::<Sender, Type>;
+                hpx::execution::experimental::detail::sync_wait_receiver<
+                    Sender, Type>;
             using state_type = typename receiver_type::shared_state;
 
             state_type state{};

--- a/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -87,7 +87,7 @@ namespace hpx::execution::experimental::detail {
         // sync_wait or sync_wait_with_variant by checking Sync_wait_type is single or variant
         using result_type = std::conditional<Type == Sync_wait_type::single,
             hpx::variant<single_result_type>,
-            predecessor_value_types<hpx::tuple, hpx::variant>>::type;
+            predecessor_value_types<hpx::tuple, hpx::variant>>; // ::type
 
         // The type of errors to store in the variant. This in itself is a
         // variant.


### PR DESCRIPTION
Proposed Changes:
Integrate sync_wait and sync_wait_with_variant. 

Question:
1. make_decayed_pack_t should be applied to sync_wait_with_variant result_type?

Note:
dont add sync_wait_with_variant.hpp and sync_wait_with_variant.cpp, because sync_wait and sync_wait_with_variant already have same name; so sync_wait_with_variant.cpp should also be integrate with sync_wait.cpp.
question: how to do sync_wait_with_variant.cpp integrate with sync_wait.cpp.???